### PR TITLE
chore(ci): use Python 3.13 in tests workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- add basic GitHub Actions workflow using Python 3.13

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab79df99348321aa41a3902af4c41d