### PR TITLE
Add ruff/black static analysis configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,9 @@ dmypy.json
 # pytype static type analyzer
 .pytype/
 
+# Ruff
+.ruff_cache/
+
 # Cython debug symbols
 cython_debug/
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "ms-python.python",
+        "ms-python.black-formatter",
+        "charliermarsh.ruff"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "editor.formatOnSave": true,
+    "python.formatting.provider": "black",
+    "python.formatting.blackArgs": ["--line-length", "88"],
+    "editor.codeActionsOnSave": {
+        "source.fixAll": true
+    },
+    "ruff.lintOnSave": "on"
+}

--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,12 @@ pyi: deps
 
 clean:
 	rm -rf build dist *.spec
+
+.PHONY: fmt lint
+fmt:
+	ruff --fix .
+	black .
+
+lint:
+	ruff .
+	black --check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ path = "src"
 [tool.uv]
 dev-dependencies = [
     "flet[all]==0.28.3",
+    "black==25.1.0",
+    "ruff==0.12.7",
 ]
 
 [tool.poetry]
@@ -43,3 +45,15 @@ flet = {extras = ["all"], version = "0.28.3"}
 
 [project.scripts]
 run = "flet run src/app.py"
+
+[tool.black]
+line-length = 88
+target-version = ["py39"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "F", "B", "W", "C90", "I", "UP"]
+ignore = ["E501"]


### PR DESCRIPTION
## Summary
- configure ruff and black for opinionated linting and formatting
- add VS Code settings and extension recommendations for linting
- expose make fmt and lint tasks

## Testing
- `PYENV_VERSION=3.11.12 ruff check .` *(fails: import sorting and typing updates needed)*
- `PYENV_VERSION=3.11.12 black --check .` *(fails: 4 files would be reformatted)*

------
https://chatgpt.com/codex/tasks/task_e_68ab79b0e78083218f8eb91b2bf27c93