### PR TITLE
Add focused unit tests and CI updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,5 +15,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
+          pip install pytest
       - name: Run tests
         run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev-dependencies = [
     "flet[all]==0.28.3",
     "black==25.1.0",
     "ruff==0.12.7",
+    "pytest==8.3.3",
 ]
 
 [tool.poetry]
@@ -42,6 +43,7 @@ package-mode = false
 
 [tool.poetry.group.dev.dependencies]
 flet = {extras = ["all"], version = "0.28.3"}
+pytest = "8.3.3"
 
 [project.scripts]
 run = "flet run src/app.py"

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -1,0 +1,39 @@
+import pytest
+
+import core.llm_adapter as llm_adapter
+from core.llm_adapter import LlamaRunner
+
+
+def test_chatml_prompt_includes_system_and_user():
+    result = LlamaRunner._chatml_prompt("sys", "user")
+    assert result == (
+        "<|im_start|>system\nsys\n<|im_end|>\n"
+        "<|im_start|>user\nuser\n<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+
+
+def test_chatml_prompt_without_system_prompt():
+    result = LlamaRunner._chatml_prompt("", "user")
+    assert result == (
+        "<|im_start|>user\nuser\n<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
+
+
+def test_load_requires_llama(monkeypatch, tmp_path):
+    monkeypatch.setattr(llm_adapter, "Llama", None)
+    runner = llm_adapter.LlamaRunner()
+    with pytest.raises(RuntimeError):
+        runner.load(str(tmp_path / "model.gguf"))
+
+
+def test_load_missing_model_raises(monkeypatch, tmp_path):
+    class DummyLlama:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(llm_adapter, "Llama", DummyLlama)
+    runner = llm_adapter.LlamaRunner()
+    with pytest.raises(FileNotFoundError):
+        runner.load(str(tmp_path / "missing.gguf"))

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,9 @@
+import sys
+
+from paths import _dev_assets_dir, _frozen_assets_dir
+
+
+def test_frozen_assets_dir_defaults_to_dev(monkeypatch):
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+    monkeypatch.setattr(sys, "executable", "/usr/bin/python")
+    assert _frozen_assets_dir() == _dev_assets_dir()


### PR DESCRIPTION
## Summary
- add unit tests for ChatML prompting, model loading error paths, and asset path detection
- include pytest in dev dependencies and CI workflow

## Testing
- `PYTHONPATH=src python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7d89e43883219991ba41e1269d32