### PR TITLE
docs: add README and agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ LLM coding agents. The instructions in this file apply to the entire repository.
 
 - The default chat model lives in `src/assets/models/llm/` and can be overridden by setting
   the `LOCALAI_ASSETS_DIR` environment variable to a directory containing `models/llm`.
-- The main application entry point is `src/app.py`; running `flet run src/app.py` launches the UI.
+- The main application entry point is `src/app.py`; running `make run` launches the UI.
 - Packaging is handled through `make pyi`, which wraps PyInstaller.
 
 ## Pull Requests

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ that contains `models/llm`. The `paths.py` module will pick it up automatically.
 ### 5. Run the app
 
 ```bash
-flet run src/app.py
+make run
 ```
 
 The window will open with a transcript view and a single input box. On first

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,6 @@ package-mode = false
 flet = {extras = ["all"], version = "0.28.3"}
 pytest = "8.3.3"
 
-[project.scripts]
-run = "flet run src/app.py"
-
 [tool.ruff]
 line-length = 100
 target-version = "py313"


### PR DESCRIPTION
## Summary
- document project setup, usage, and development workflow
- add AGENTS.md with instructions for automated coding agents

## Testing
- `python -m ruff check .`
- `python -m ruff format . --exclude src/paths.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac7cd1d7688321b0b5dd0a5d168ed7