### PR TITLE
Remove leftover token from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,5 +167,3 @@ storage/
 
 src/assets/models/**
 src/storage/models/**
-
-# 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


### PR DESCRIPTION
## Summary
- remove leftover token from `.gitignore`
- ensure `.gitignore` ends with newline
- attempt to scan repository for secrets

## Testing
- `python -m ruff format .`
- `python -m ruff check .`
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'core'/'paths')*
- `rg -n "hf_"`


------
https://chatgpt.com/codex/tasks/task_e_68b0b1ab0cec8321a890ee1dc5898db4