### PR TITLE
Refactor directory creation into startup function

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,12 +1,14 @@
 import flet as ft
 
 from core.llm_adapter import LlamaRunner
+from paths import ensure_app_dirs
 from ui.chat import ChatView
 
 APP_TITLE = "Local AI (Chat)"
 
 
 def main(page: ft.Page) -> None:
+    ensure_app_dirs()
     page.title = APP_TITLE
     page.window_width = 900
     page.window_height = 700

--- a/src/paths.py
+++ b/src/paths.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 ENV_ASSETS = "LOCALAI_ASSETS_DIR"
 
+
 def _env_assets_dir() -> Path | None:
     p = os.environ.get(ENV_ASSETS)
     if not p:
@@ -47,5 +48,9 @@ LLM_MODELS_DIR = ASSETS_DIR / "models" / "llm"
 
 APP_DIR = Path.home() / "LocalAI"
 OUTPUTS_DIR = APP_DIR / "outputs"
-for p in (APP_DIR, OUTPUTS_DIR):
-    p.mkdir(parents=True, exist_ok=True)
+
+
+def ensure_app_dirs() -> None:
+    """Ensure application data directories exist."""
+    for p in (APP_DIR, OUTPUTS_DIR):
+        p.mkdir(parents=True, exist_ok=True)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -29,6 +29,7 @@ def reload_paths(tmp_assets=None, frozen=False, meipass=None, exe=None):
         # then recompute ASSETS_DIR/LLM_MODELS_DIR based on that
         paths.__file__ = str(tmp_assets.parent / "paths.py")  # type: ignore
         importlib.reload(paths)
+    paths.ensure_app_dirs()
     return paths
 
 
@@ -46,6 +47,8 @@ def test_dev_assets_dir(tmp_path, monkeypatch):
     if "paths" in sys.modules:
         del sys.modules["paths"]
     import paths
+
+    paths.ensure_app_dirs()
 
     assert paths.LLM_MODELS_DIR.resolve() == llm_dir.resolve()
 


### PR DESCRIPTION
## Summary
- expose `ensure_app_dirs()` to lazily create `APP_DIR` and `OUTPUTS_DIR`
- call `ensure_app_dirs()` at app startup
- update tests to invoke `ensure_app_dirs()`

## Testing
- `PYENV_VERSION=3.11.12 ruff format .`
- `PYENV_VERSION=3.11.12 ruff check .`
- `PYENV_VERSION=3.11.12 PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0b1d722408321979d0958bce4848c