### PR TITLE
docs: add contributing guidelines and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,111 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and
+healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the
+  experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their
+  explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior
+and will take appropriate and fair corrective action in response to any behavior that they deem
+inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits,
+code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and
+will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is
+officially representing the community in public spaces. Examples of representing our community
+include using an official e-mail address, posting via an official social media account, or acting as
+an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project
+maintainers at community@local-ai.dev. All complaints will be reviewed and investigated promptly and
+fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any
+incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for
+any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or
+unwelcome.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the
+nature of the violation and an explanation of why the behavior was inappropriate. A public apology
+may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people
+involved, including unsolicited interaction with those enforcing the Code of Conduct, for a
+specified period of time. This includes avoiding interactions in community spaces as well as
+external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate
+behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the
+community for a specified period of time. No public or private interaction with the people involved,
+including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including
+sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement
+of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by Mozilla's code of conduct enforcement ladder:
+https://github.com/mozilla/diversity.
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to Local AI
+
+Thanks for taking the time to contribute! The following guidelines help you set up your
+environment and ensure your contributions meet project standards.
+
+## Setup
+
+1. **Install Python**: Local AI requires Python 3.9 or newer.
+2. **Create a virtual environment**:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows use `.venv\Scripts\activate`
+   ```
+3. **Install dependencies** using either `pip` or [`uv`](https://github.com/astral-sh/uv):
+   ```bash
+   pip install -r <(python - <<'PY'
+   import toml
+   print('\n'.join(toml.load('pyproject.toml')['project']['dependencies']))
+   PY
+   )
+   pip install flet[all]==0.28.3 ruff black pytest
+   ```
+   Or with `uv`:
+   ```bash
+   uv sync
+   ```
+
+## Coding Standards
+
+- Keep line length under **100 characters**.
+- Format code with `ruff format .` and lint with `ruff check .`.
+- Ensure all tests pass by running `pytest`.
+- When modifying behavior, add or update tests as needed.
+
+These commands are also available through the `Makefile`:
+```bash
+make fmt     # format
+make lint    # lint only
+make test    # run tests
+```
+
+## Pull Request Process
+
+1. Fork the repository and create your feature or bug fix.
+2. Run formatting, linting, and tests before committing.
+3. Push your changes and open a pull request against `main`.
+4. Reference relevant files and test output in the pull request description.
+5. By participating, you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+We appreciate your contributions and efforts to improve Local AI!

--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ The resulting application bundle will appear under `dist/`.
 
 ## Contributing
 
-Pull requests and issues are welcome. Please format code with `ruff format`, run
-`ruff check` and ensure `pytest` passes before submitting.
+Pull requests and issues are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup details,
+coding standards, and the pull request process. By participating, you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guide outlining setup, coding standards, and pull request process
- adopt Contributor Covenant-based code of conduct
- link new community docs from the README

## Testing
- `ruff format .`
- `ruff check .`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0bcb4481083219380ea8c3686ad3a