### PR TITLE
chore: move pytest-asyncio to dev deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ keywords = ["local-ai", "llm", "flet", "chatbot"]
 dependencies = [
   "flet==0.28.3",
   "llama-cpp-python>=0.3.15,<0.4",
-  "pytest-asyncio>=1.1.0",
 ]
 
 [tool.flet]
@@ -39,6 +38,7 @@ dev-dependencies = [
     "black==25.1.0",
     "ruff==0.12.7",
     "pytest==8.3.3",
+    "pytest-asyncio>=1.1.0",
 ]
 
 [tool.poetry]
@@ -47,6 +47,7 @@ package-mode = false
 [tool.poetry.group.dev.dependencies]
 flet = {extras = ["all"], version = "0.28.3"}
 pytest = "8.3.3"
+pytest-asyncio = ">=1.1.0"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary
- remove pytest-asyncio from main project dependencies
- include pytest-asyncio in dev deps for uv and poetry

## Testing
- `PYENV_VERSION=3.13.3 ruff format .`
- `PYENV_VERSION=3.13.3 ruff check .`
- `PYENV_VERSION=3.13.3 PYTHONPATH=src pytest` *(fails: async plugin missing)*
- `PYENV_VERSION=3.13.3 uv pip install --system "pytest-asyncio>=1.1.0"` *(failed: No interpreter / network issue)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0c83288c832183335d9f79851eb5