### PR TITLE
feat: centralize configuration constants

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -4,11 +4,10 @@ from pathlib import Path
 
 import flet as ft
 
+from config import APP_TITLE, ENV_MODEL
 from core.llm_adapter import LlamaRunner
 from paths import ensure_app_dirs
 from ui.chat import ChatView
-
-APP_TITLE = "Local AI (Chat)"
 
 
 def main(page: ft.Page, model_path: Path | None) -> None:
@@ -42,7 +41,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--model",
         help="Path to GGUF model file",
-        default=os.environ.get("LOCALAI_MODEL"),
+        default=os.environ.get(ENV_MODEL),
     )
     args = parser.parse_args()
     model = Path(args.model).expanduser() if args.model else None

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+APP_TITLE = "Local AI (Chat)"
+ENV_MODEL = "LOCALAI_MODEL"
+ENV_ASSETS = "LOCALAI_ASSETS_DIR"
+DEFAULT_APP_DIR = Path.home() / "LocalAI"

--- a/src/paths.py
+++ b/src/paths.py
@@ -2,7 +2,7 @@ import os
 import sys
 from pathlib import Path
 
-ENV_ASSETS = "LOCALAI_ASSETS_DIR"
+from config import DEFAULT_APP_DIR, ENV_ASSETS
 
 
 def _env_assets_dir() -> Path | None:
@@ -46,7 +46,7 @@ ASSETS_DIR = _assets_dir()
 
 LLM_MODELS_DIR = ASSETS_DIR / "models" / "llm"
 
-APP_DIR = Path.home() / "LocalAI"
+APP_DIR = DEFAULT_APP_DIR
 OUTPUTS_DIR = APP_DIR / "outputs"
 
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,6 +1,8 @@
 import importlib
 import sys
 
+from config import ENV_ASSETS
+
 
 def reload_paths(tmp_assets=None, frozen=False, meipass=None, exe=None):
     # Build a fresh module namespace so globals recompute on import
@@ -41,7 +43,7 @@ def test_dev_assets_dir(tmp_path, monkeypatch):
     llm_dir.mkdir(parents=True)
 
     # Tell paths.py to use our temp assets
-    monkeypatch.setenv("LOCALAI_ASSETS_DIR", str(assets_root))
+    monkeypatch.setenv(ENV_ASSETS, str(assets_root))
 
     # Reload module so it picks up the env override
     if "paths" in sys.modules:


### PR DESCRIPTION
## Summary
- add `config.py` with app title, environment variables, and default data directory
- import shared constants across modules to remove hardcoded values

## Testing
- `PYENV_VERSION=3.13.3 ruff format .`
- `PYENV_VERSION=3.13.3 ruff check .`
- `PYENV_VERSION=3.13.3 PYTHONPATH=src pytest` *(fails: async tests require plugin; installing `pytest-asyncio` failed due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0c7a06f88321a277c1ab5824b362