### PR TITLE
docs: add template usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ Local AI is a minimal desktop chat application that lets you run small language 
 - Configurable asset directory and model location.
 - Tested using `pytest` with a lightweight fake model for fast feedback.
 
+## Using this template
+
+To start a new project from this repository:
+
+1. Click **Use this template** on GitHub and choose **Create a new repository**.
+2. Rename the project:
+   - Update the repository name on GitHub.
+   - Replace references to "Local AI" in `README.md` and module names if needed.
+3. Update project metadata:
+   - Edit `pyproject.toml` with your package name, description, and author details.
+   - Adjust the license and other documentation to match your project.
+4. Customize the code:
+   - Modify modules under `src/` and tests in `tests/` to fit your requirements.
+   - Adjust dependencies in `pyproject.toml` as required.
+
 ## Project Layout
 
 ```text


### PR DESCRIPTION
## Summary
- document how to use this repository as a template and adapt it to a new project

## Testing
- `ruff format .`
- `ruff check .`
- `PYTHONPATH=src pytest` *(fails: Missing async plugin; attempted `pip install pytest-asyncio` but install failed due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1030983883218afee6804d862df5