### PR TITLE
chore: remove poetry config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,15 +40,6 @@ dev-dependencies = [
     "pytest==8.3.3",
     "pytest-asyncio>=1.1.0",
 ]
-
-[tool.poetry]
-package-mode = false
-
-[tool.poetry.group.dev.dependencies]
-flet = {extras = ["all"], version = "0.28.3"}
-pytest = "8.3.3"
-pytest-asyncio = ">=1.1.0"
-
 [tool.ruff]
 line-length = 100
 target-version = "py313"


### PR DESCRIPTION
## Summary
- remove leftover Poetry configuration
- rely on uv `dev-dependencies` for development tooling

## Testing
- `PYENV_VERSION=3.12.10 ruff format .`
- `PYENV_VERSION=3.12.10 ruff check .`
- `PYENV_VERSION=3.12.10 PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb253319948321b0cd7cf7d853626e